### PR TITLE
chore: update config for Google provider >= 4.x

### DIFF
--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -216,14 +216,8 @@ variable "services_secondary_range_name" {
   default     = null
 }
 
-variable "enable_workload_identity" {
-  description = "Enable Workload Identity on the cluster"
-  default     = false
-  type        = bool
-}
-
-variable "identity_namespace" {
-  description = "Workload Identity Namespace. Default sets project based namespace [project_id].svc.id.goog"
-  default     = null
+variable "release_channel" {
+  description = "The release channel of this cluster"
   type        = string
+  default     = "UNSPECIFIED"
 }


### PR DESCRIPTION
This PR updates the gke-cluster module code to be compatible with Google Provider 4.x.
Any other config in this repo was not touched as it is not used by us.